### PR TITLE
Fix transient condition when device path is not yet available on host

### DIFF
--- a/hack/license-header.txt
+++ b/hack/license-header.txt
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
 SPDX-License-Identifier: Apache-2.0

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -79,6 +79,8 @@ var _ = Describe("Node", func() {
 					},
 				},
 			}
+
+			mockOS.EXPECT().Stat(devicePath).Return(nil, nil)
 		})
 
 		It("should fail if the volume is already mounted", func(ctx SpecContext) {
@@ -107,7 +109,6 @@ var _ = Describe("Node", func() {
 			statusErr, ok := status.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(statusErr.Code()).To(Equal(codes.Internal))
-
 		})
 
 		It("should fail if the mount operation fails", func(ctx SpecContext) {
@@ -129,7 +130,6 @@ var _ = Describe("Node", func() {
 			_, err := drv.NodeStageVolume(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 	})
 
 	Describe("NodePublishVolume", func() {
@@ -598,7 +598,6 @@ var _ = Describe("Node", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(SatisfyAll(
 				HaveField("Usage", ContainElements([]*csi.VolumeUsage{
-
 					{
 						Available: 0,
 						Total:     0,
@@ -615,6 +614,5 @@ var _ = Describe("Node", func() {
 				)),
 			))
 		})
-
 	})
 })

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/pkg/utils/os/mock_osutils_unix.go
+++ b/pkg/utils/os/mock_osutils_unix.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 //
 


### PR DESCRIPTION
# Proposed Changes

We currently fail with an internal error if the device path is not ready on the host yet. The error occurs when we try to mount the volume. This leads to unnecessary error events.

In this PR we try to address this issue by return an `Unavailable` error in case the device on the host is not ready yet. This will trigger a re-try.