### PR TITLE
Node driver should not fail if a volume is already mounted

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -60,7 +60,8 @@ func (d *driver) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequ
 	}
 	klog.InfoS("Check if volume is already mounted")
 	if !notMnt {
-		return nil, status.Errorf(codes.Internal, "Volume %s is already mounted under path %s", req.GetVolumeId(), targetPath)
+		klog.InfoS("Staged volume is already mounted", "Volume", req.GetVolumeId())
+		return &csi.NodeStageVolumeResponse{}, nil
 	}
 	klog.InfoS("Create target directory")
 	if err := d.os.MkdirAll(targetPath, 0750); err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -83,10 +83,10 @@ var _ = Describe("Node", func() {
 			mockOS.EXPECT().Stat(devicePath).Return(nil, nil)
 		})
 
-		It("should fail if the volume is already mounted", func(ctx SpecContext) {
+		It("should not fail if the volume is already mounted", func(ctx SpecContext) {
 			mockMounter.EXPECT().IsLikelyNotMountPoint(targetPath).Return(false, nil)
 			_, err := drv.NodeStageVolume(ctx, req)
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should fail if the mount point validation fails", func(ctx SpecContext) {


### PR DESCRIPTION
# Proposed Changes

- If staged volume is already mounted logging the info and returning instead of throwing error.
- Adjust test case

Fixes #454 
