### PR TITLE
Add mkfs options parameter to volume context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME) -v ./cmd/
 
 docker-build:
-	docker build $(BUILDARGS) -t ${IMG} -f Dockerfile .
+	docker build $(BUILDARGS) -t ${IMG} -f Dockerfile . --load
 
 docker-push:
 	docker push ${IMG}

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -33,6 +33,8 @@ const (
 	ParameterNodeID = "node_id"
 	// ParameterDeviceName is the device name parameter
 	ParameterDeviceName = "device_name"
+	// ParameterReadOnly is the name of the parameter used to specify whether the volume should be mounted as read-only
+	ParameterReadOnly = "readOnly"
 	// ParameterMkfsOptions is the name of the parameter used to specify the options for the mkfs command
 	ParameterMkfsOptions = "mkfs_options"
 

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -33,6 +33,8 @@ const (
 	ParameterNodeID = "node_id"
 	// ParameterDeviceName is the device name parameter
 	ParameterDeviceName = "device_name"
+	// ParameterMkfsOptions is the name of the parameter used to specify the options for the mkfs command
+	ParameterMkfsOptions = "mkfs_options"
 
 	CSIDriverName    = "csi.ironcore.dev"
 	topologyKey      = "topology." + CSIDriverName + "/zone"

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -57,6 +57,11 @@ func (d *driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		fstype = FSTypeExt4
 	}
 
+	mkfsOptions, ok := params[ParameterMkfsOptions]
+	if !ok {
+		mkfsOptions = ""
+	}
+
 	volumeClass, ok := params[ParameterType]
 	if !ok {
 		return nil, status.Errorf(codes.Internal, "Required parameter %s is missing", ParameterType)
@@ -136,6 +141,7 @@ func (d *driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				ParameterVolumePool:   volumePoolName,
 				ParameterCreationTime: time.Unix(volume.CreationTimestamp.Unix(), 0).String(),
 				ParameterFSType:       fstype,
+				ParameterMkfsOptions:  mkfsOptions,
 			},
 			ContentSource:      req.GetVolumeContentSource(),
 			AccessibleTopology: accessibleTopology,

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -467,7 +467,7 @@ func validateDeviceName(volume *storagev1alpha1.Volume, machine *computev1alpha1
 			}
 		}
 	}
-	return "", fmt.Errorf("failed to get device name of volume %s name from machine %s", client.ObjectKeyFromObject(volume), client.ObjectKeyFromObject(machine))
+	return "", fmt.Errorf("failed to get device name of volume %s from machine %s", client.ObjectKeyFromObject(volume), client.ObjectKeyFromObject(machine))
 }
 
 func isValidVolumeCapabilities(volCaps []*csi.VolumeCapability) bool {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Node", func() {
 		It("should fail if the mount operation fails", func(ctx SpecContext) {
 			mockMounter.EXPECT().IsLikelyNotMountPoint(targetPath).Return(true, nil)
 			mockOS.EXPECT().MkdirAll(targetPath, os.FileMode(0750)).Return(nil)
-			mockMounter.EXPECT().FormatAndMount(devicePath, targetPath, fstype, mountOptions).Return(errors.New("failed to mount volume"))
+			mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(devicePath, targetPath, fstype, mountOptions, nil, nil).Return(errors.New("failed to mount volume"))
 			_, err := drv.NodeStageVolume(ctx, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Failed to mount volume"))
@@ -126,7 +126,7 @@ var _ = Describe("Node", func() {
 		It("should stage the volume", func(ctx SpecContext) {
 			mockMounter.EXPECT().IsLikelyNotMountPoint(targetPath).Return(true, nil)
 			mockOS.EXPECT().MkdirAll(targetPath, os.FileMode(0750)).Return(nil)
-			mockMounter.EXPECT().FormatAndMount(devicePath, targetPath, fstype, mountOptions).Return(nil)
+			mockMounter.EXPECT().FormatAndMountSensitiveWithFormatOptions(devicePath, targetPath, fstype, mountOptions, nil, nil).Return(nil)
 			_, err := drv.NodeStageVolume(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/pkg/utils/mount/mock_mountutils_unix.go
+++ b/pkg/utils/mount/mock_mountutils_unix.go
@@ -58,18 +58,18 @@ func (mr *MockMountWrapperMockRecorder) CanSafelySkipMountPointCheck() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanSafelySkipMountPointCheck", reflect.TypeOf((*MockMountWrapper)(nil).CanSafelySkipMountPointCheck))
 }
 
-// FormatAndMount mocks base method.
-func (m *MockMountWrapper) FormatAndMount(source, target, fstype string, options []string) error {
+// FormatAndMountSensitiveWithFormatOptions mocks base method.
+func (m *MockMountWrapper) FormatAndMountSensitiveWithFormatOptions(source, target, fstype string, options, sensitiveOptions, formatOptions []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FormatAndMount", source, target, fstype, options)
+	ret := m.ctrl.Call(m, "FormatAndMountSensitiveWithFormatOptions", source, target, fstype, options, sensitiveOptions, formatOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// FormatAndMount indicates an expected call of FormatAndMount.
-func (mr *MockMountWrapperMockRecorder) FormatAndMount(source, target, fstype, options any) *gomock.Call {
+// FormatAndMountSensitiveWithFormatOptions indicates an expected call of FormatAndMountSensitiveWithFormatOptions.
+func (mr *MockMountWrapperMockRecorder) FormatAndMountSensitiveWithFormatOptions(source, target, fstype, options, sensitiveOptions, formatOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatAndMount", reflect.TypeOf((*MockMountWrapper)(nil).FormatAndMount), source, target, fstype, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatAndMountSensitiveWithFormatOptions", reflect.TypeOf((*MockMountWrapper)(nil).FormatAndMountSensitiveWithFormatOptions), source, target, fstype, options, sensitiveOptions, formatOptions)
 }
 
 // GetMountRefs mocks base method.

--- a/pkg/utils/mount/mountutils_unix.go
+++ b/pkg/utils/mount/mountutils_unix.go
@@ -18,7 +18,7 @@ import (
 // SafeFormatAndMount). Defined it explicitly so that it can be mocked.
 type MountWrapper interface {
 	k8smountutils.Interface
-	FormatAndMount(source string, target string, fstype string, options []string) error
+	FormatAndMountSensitiveWithFormatOptions(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error
 	NewResizeFs() (Resizefs, error)
 }
 


### PR DESCRIPTION
# Proposed Changes

This update introduces a new parameter, `ParameterMkfsOptions`, to the volume context for specifying options for the `mkfs` command. Key changes include:

- The new parameter is utilized during the volume stage.
- The volume format and mount method are modified to process the new format options.
- The corresponding mock method for testing is updated with the new parameter.
- The mount method in the `NodeStageVolume` test was updated from `FormatAndMount` to `FormatAndMountSensitiveWithFormatOptions`

_This change is borrowed from the GitLab fork of CSI driver, originally authored by @FlorinPeter. Thanks for the contribution!_
