### PR TITLE
Truncate `deviceName` if longer than 20 chars

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -457,7 +457,13 @@ func validateDeviceName(volume *storagev1alpha1.Volume, machine *computev1alpha1
 			device := ptr.Deref[string](va.Device, "")
 			if va.Name == vaName && device != "" {
 				klog.InfoS("Found device in machine status to use for volume", "Device", device, "Volume", client.ObjectKeyFromObject(volume))
-				return "/dev/disk/by-id/virtio-" + device + "-" + handle, nil
+				deviceName := device + "-" + handle
+				// if deviceName is longer then 20 chars truncate it
+				// see https://github.com/torvalds/linux/blob/v6.6/include/uapi/linux/virtio_blk.h#L58
+				if len(deviceName) > 20 {
+					deviceName = deviceName[:20]
+				}
+				return "/dev/disk/by-id/virtio-" + deviceName, nil
 			}
 		}
 	}


### PR DESCRIPTION
# Proposed Changes

The `deviceName` is now truncated to 20 characters for compatibility with Virtio block devices. See [Linux Virtio Block header file](https://github.com/torvalds/linux/blob/ffc253263a1375a65fa6c9f62a893e9767fbebfa/include/uapi/linux/virtio_blk.h#L58) for reference.

_This change was borrowed from the GitLab fork of CSI driver, originally authored by @FlorinPeter. Thanks for the contribution!_
