### PR TITLE
Bump golangci-lint to v2.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.4

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ KUSTOMIZE_VERSION ?= v5.5.0
 ADDLICENSE_VERSION ?= v1.1.1
 MOCKGEN_VERSION ?= v0.6.0
 GOIMPORTS_VERSION ?= v0.31.0
-GOLANGCI_LINT_VERSION ?= v2.1
+GOLANGCI_LINT_VERSION ?= v2.4
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize


### PR DESCRIPTION
# Proposed Changes

Bump golangci-lint to v2.4.
