### PR TITLE
Refactor Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 # Image URL to use all building/pushing image targets
 IMG ?= ironcore-csi-driver:latest
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.32.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -123,6 +121,10 @@ ADDLICENSE_VERSION ?= v1.1.1
 MOCKGEN_VERSION ?= v0.6.0
 GOIMPORTS_VERSION ?= v0.31.0
 GOLANGCI_LINT_VERSION ?= v2.4
+#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d.%d",$$3, $$2}')
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -126,15 +126,10 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d.%d",$$3, $$2}')
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q $(KUSTOMIZE_VERSION); then \
-		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
-		rm -rf $(LOCALBIN)/kustomize; \
-	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ docker-push:
 
 deploy:
 	cd config/manager && $(KUSTOMIZE) edit set image ironcore-csi-driver=${IMG}
-	kubectl apply -k config/default
+	$(KUBECTL) apply -k config/default
 
 undeploy:
-	kubectl delete -k  config/default
+	$(KUBECTL) delete -k  config/default
 
 .PHONY: fmt
 fmt: goimports ## Run goimports against code.
@@ -107,6 +107,7 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 ## Tool Binaries
+KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 ADDLICENSE ?= $(LOCALBIN)/addlicense

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,6 @@ help: ## Display this help.
 
 BINARY_NAME=ironcore-csi-driver
 
-BUILDARGS ?=
-
 clean:
 	rm -f $(BINARY_NAME)
 
@@ -57,7 +55,7 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME) -v ./cmd/
 
 docker-build:
-	$(CONTAINER_TOOL) build $(BUILDARGS) -t ${IMG} -f Dockerfile . --load
+	$(CONTAINER_TOOL) build -t ${IMG} .
 
 docker-push:
 	$(CONTAINER_TOOL) push ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# CONTAINER_TOOL defines the container tool to be used for building images.
+# Be aware that the target commands are only tested with Docker which is
+# scaffolded by default. However, you might want to replace it to use other
+# tools. (i.e. podman)
+CONTAINER_TOOL ?= docker
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -58,10 +64,10 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME) -v ./cmd/
 
 docker-build:
-	docker build $(BUILDARGS) -t ${IMG} -f Dockerfile . --load
+	$(CONTAINER_TOOL) build $(BUILDARGS) -t ${IMG} -f Dockerfile . --load
 
 docker-push:
-	docker push ${IMG}
+	$(CONTAINER_TOOL) push ${IMG}
 
 deploy:
 	cd config/manager && $(KUSTOMIZE) edit set image ironcore-csi-driver=${IMG}

--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,8 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 BINARY_NAME=ironcore-csi-driver
-DOCKER_IMAGE=ironcore-csi-driver
 
 BUILDARGS ?=
-
-# For Development Build #################################################################
-# Docker.io username and tag
-DOCKER_USER=ironcore
-DOCKER_IMAGE_TAG=latest
-# For Development Build #################################################################
 
 clean:
 	rm -f $(BINARY_NAME)


### PR DESCRIPTION
Refactor Makefile by adding changes from the upstream kubebuilder template.

# Proposed Changes

- Add `go-install-tool` function
- Remove hardcoded `ENVTEST_K8S_VERSION`
- Add `CONTAINER_TOOL` env variable
- Remove unused `DOCKER` variables
- Add `KUBECTL` variable
- Use `go-install-tool` for kustomize installation
- Remove extra build arguments from `docker-build`

Fixes #609 

