### PR TITLE
Ignore "not found"-errors when deleting volumes

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -185,6 +185,10 @@ func (d *driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		},
 	}
 	if err := d.ironcoreClient.Delete(ctx, vol); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.InfoS("Volume not found, assuming already deleted", "Volume", req.GetVolumeId())
+			return &csi.DeleteVolumeResponse{}, nil
+		}
 		return nil, status.Errorf(codes.Internal, "Failed to delete volume %s: %v", client.ObjectKeyFromObject(vol), err)
 	}
 	klog.InfoS("Deleted volume", "Volume", req.GetVolumeId())

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -342,6 +342,14 @@ var _ = Describe("Controller", func() {
 		wg.Wait()
 	})
 
+	It("should succeed when deleting a non-existent volume", func(ctx SpecContext) {
+		By("deleting a volume that does not exist")
+		_, err := drv.DeleteVolume(ctx, &csi.DeleteVolumeRequest{
+			VolumeId: "non-existent-volume",
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should expand the volume size", func(ctx SpecContext) {
 		By("resizing the volume")
 		newVolumeSize := int64(10 * 1024 * 1024 * 1024)


### PR DESCRIPTION
# Proposed Changes

Per [CSI spec](https://github.com/container-storage-interface/spec/blob/master/spec.md#deletevolume), DeleteVolume should succeed if the volume does not exist.
This PR makes sure to return success instead of an internal error
when the volume does not exist.

Fixes #658
