### PR TITLE
Delete leftover socket on startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/dell/gocsi"
 	csictx "github.com/dell/gocsi/context"
+	csiutils "github.com/dell/gocsi/utils/csi"
 	"github.com/ironcore-dev/controller-utils/configutils"
 	"github.com/ironcore-dev/ironcore-csi-driver/cmd/options"
 	"github.com/ironcore-dev/ironcore-csi-driver/pkg/driver"
@@ -43,10 +43,11 @@ func init() {
 	flag.StringVar(&targetKubeconfig, "target-kubeconfig", "", "Path pointing to the target kubeconfig.")
 	flag.StringVar(&ironcoreKubeconfig, "ironcore-kubeconfig", "", "Path pointing to the ironcore kubeconfig.")
 	flag.StringVar(&driverName, "driver-name", driver.CSIDriverName, "Override the default driver name.")
-	flag.Parse()
 }
 
 func main() {
+	flag.Parse()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -155,14 +156,13 @@ func buildKubernetesClient(kubeconfig string) (client.Client, error) {
 }
 
 func removeUnixSocketIfExists(endpoint string) error {
-	u, err := url.Parse(endpoint)
+	proto, addr, err := csiutils.ParseProtoAddr(endpoint)
 	if err != nil {
 		return fmt.Errorf("could not parse CSI endpoint: %w", err)
 	}
 
-	if u.Scheme == "unix" {
-		err = common.CleanupSocketIfExists(u.Path)
-		if err != nil {
+	if proto == "unix" {
+		if err := common.CleanupSocketIfExists(addr); err != nil {
 			return fmt.Errorf("error cleaning up socket: %w", err)
 		}
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -8,108 +8,71 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestRemoveUnixSocketIfExists(t *testing.T) {
-	tests := []struct {
-		name          string
-		endpoint      string
-		createSocket  bool
-		expectRemoved bool
-		expectError   bool
-		socketRelPath string
-	}{
-		{
-			name:          "unix scheme with two slashes removes correct relative path",
-			endpoint:      "unix://csi/csi.sock",
-			createSocket:  true,
-			expectRemoved: true,
-			socketRelPath: "csi/csi.sock",
-		},
-		{
-			name:          "bare path without scheme removes socket",
-			endpoint:      "csi/csi.sock",
-			createSocket:  true,
-			expectRemoved: true,
-			socketRelPath: "csi/csi.sock",
-		},
-		{
-			name:          "no socket file present does not error",
-			endpoint:      "unix://csi/csi.sock",
-			createSocket:  false,
-			expectRemoved: false,
-			expectError:   false,
-			socketRelPath: "csi/csi.sock",
-		},
-		{
-			name:        "tcp endpoint does not attempt socket removal",
-			endpoint:    "tcp://127.0.0.1:9090",
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Use a short temp directory to avoid exceeding Unix socket path length limit (104/108 bytes)
-			tmpDir, err := os.MkdirTemp("/tmp", "csit")
-			if err != nil {
-				t.Fatalf("failed to create temp dir: %v", err)
-			}
-			t.Cleanup(func() {
-				os.RemoveAll(tmpDir)
-			})
-
-			origDir, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("failed to get working directory: %v", err)
-			}
-			if err := os.Chdir(tmpDir); err != nil {
-				t.Fatalf("failed to chdir to temp dir: %v", err)
-			}
-			t.Cleanup(func() {
-				_ = os.Chdir(origDir)
-			})
-
-			var socketPath string
-			if tt.socketRelPath != "" {
-				socketPath = filepath.Join(tmpDir, tt.socketRelPath)
-			}
-
-			if tt.createSocket && socketPath != "" {
-				if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
-					t.Fatalf("failed to create socket parent dir: %v", err)
-				}
-				listener, err := net.Listen("unix", socketPath)
-				if err != nil {
-					t.Fatalf("failed to create test socket: %v", err)
-				}
-				// Prevent automatic removal of socket file on close (Go 1.21+ default)
-				listener.(*net.UnixListener).SetUnlinkOnClose(false)
-				listener.Close()
-
-				if _, err := os.Stat(socketPath); os.IsNotExist(err) {
-					t.Fatalf("socket file was not created at %s", socketPath)
-				}
-			}
-
-			err = removeUnixSocketIfExists(tt.endpoint)
-
-			if tt.expectError && err == nil {
-				t.Errorf("expected error but got nil")
-			}
-			if !tt.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-
-			if tt.createSocket && socketPath != "" {
-				_, statErr := os.Stat(socketPath)
-				if tt.expectRemoved && !os.IsNotExist(statErr) {
-					t.Errorf("expected socket at %s to be removed, but it still exists", socketPath)
-				}
-				if !tt.expectRemoved && os.IsNotExist(statErr) {
-					t.Errorf("expected socket at %s to still exist, but it was removed", socketPath)
-				}
-			}
-		})
-	}
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
 }
+
+var _ = Describe("removeUnixSocketIfExists", func() {
+	var (
+		tmpDir  string
+		origDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		// Use a short temp directory to avoid exceeding Unix socket path length limit (104/108 bytes)
+		tmpDir, err = os.MkdirTemp("/tmp", "csit")
+		Expect(err).NotTo(HaveOccurred())
+
+		origDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.Chdir(tmpDir)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.Chdir(origDir)).To(Succeed())
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	createSocket := func(relPath string) string {
+		socketPath := filepath.Join(tmpDir, relPath)
+		Expect(os.MkdirAll(filepath.Dir(socketPath), 0o755)).To(Succeed())
+
+		listener, err := net.Listen("unix", socketPath)
+		Expect(err).NotTo(HaveOccurred())
+		listener.(*net.UnixListener).SetUnlinkOnClose(false)
+		listener.Close()
+
+		Expect(socketPath).To(BeAnExistingFile())
+		return socketPath
+	}
+
+	It("should remove socket for unix scheme with two slashes", func() {
+		socketPath := createSocket("csi/csi.sock")
+
+		Expect(removeUnixSocketIfExists("unix://csi/csi.sock")).To(Succeed())
+		Expect(socketPath).NotTo(BeAnExistingFile())
+	})
+
+	It("should remove socket for bare path without scheme", func() {
+		socketPath := createSocket("csi/csi.sock")
+
+		Expect(removeUnixSocketIfExists("csi/csi.sock")).To(Succeed())
+		Expect(socketPath).NotTo(BeAnExistingFile())
+	})
+
+	It("should not error when no socket file is present", func() {
+		Expect(removeUnixSocketIfExists("unix://csi/csi.sock")).To(Succeed())
+	})
+
+	It("should not attempt socket removal for tcp endpoint", func() {
+		Expect(removeUnixSocketIfExists("tcp://127.0.0.1:9090")).To(Succeed())
+	})
+})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveUnixSocketIfExists(t *testing.T) {
+	tests := []struct {
+		name          string
+		endpoint      string
+		createSocket  bool
+		expectRemoved bool
+		expectError   bool
+		socketRelPath string
+	}{
+		{
+			name:          "unix scheme with two slashes removes correct relative path",
+			endpoint:      "unix://csi/csi.sock",
+			createSocket:  true,
+			expectRemoved: true,
+			socketRelPath: "csi/csi.sock",
+		},
+		{
+			name:          "bare path without scheme removes socket",
+			endpoint:      "csi/csi.sock",
+			createSocket:  true,
+			expectRemoved: true,
+			socketRelPath: "csi/csi.sock",
+		},
+		{
+			name:          "no socket file present does not error",
+			endpoint:      "unix://csi/csi.sock",
+			createSocket:  false,
+			expectRemoved: false,
+			expectError:   false,
+			socketRelPath: "csi/csi.sock",
+		},
+		{
+			name:        "tcp endpoint does not attempt socket removal",
+			endpoint:    "tcp://127.0.0.1:9090",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use a short temp directory to avoid exceeding Unix socket path length limit (104/108 bytes)
+			tmpDir, err := os.MkdirTemp("/tmp", "csit")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() {
+				os.RemoveAll(tmpDir)
+			})
+
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("failed to get working directory: %v", err)
+			}
+			if err := os.Chdir(tmpDir); err != nil {
+				t.Fatalf("failed to chdir to temp dir: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = os.Chdir(origDir)
+			})
+
+			var socketPath string
+			if tt.socketRelPath != "" {
+				socketPath = filepath.Join(tmpDir, tt.socketRelPath)
+			}
+
+			if tt.createSocket && socketPath != "" {
+				if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+					t.Fatalf("failed to create socket parent dir: %v", err)
+				}
+				listener, err := net.Listen("unix", socketPath)
+				if err != nil {
+					t.Fatalf("failed to create test socket: %v", err)
+				}
+				// Prevent automatic removal of socket file on close (Go 1.21+ default)
+				listener.(*net.UnixListener).SetUnlinkOnClose(false)
+				listener.Close()
+
+				if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+					t.Fatalf("socket file was not created at %s", socketPath)
+				}
+			}
+
+			err = removeUnixSocketIfExists(tt.endpoint)
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tt.createSocket && socketPath != "" {
+				_, statErr := os.Stat(socketPath)
+				if tt.expectRemoved && !os.IsNotExist(statErr) {
+					t.Errorf("expected socket at %s to be removed, but it still exists", socketPath)
+				}
+				if !tt.expectRemoved && os.IsNotExist(statErr) {
+					t.Errorf("expected socket at %s to still exist, but it was removed", socketPath)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This uses the same helper function gocsi itself
uses to exract the listen address and protocol.

Fixes #664 
